### PR TITLE
added career_type field

### DIFF
--- a/lms/app/(dashboard)/(routes)/admin/companies/[companyId]/careers/[careerId]/_components/form-type.ts
+++ b/lms/app/(dashboard)/(routes)/admin/companies/[companyId]/careers/[careerId]/_components/form-type.ts
@@ -31,6 +31,7 @@ export const formSchema = z.object({
     .nullable()
     .optional(),
   career_url: z.string().url("Invalid URL").nullable().optional(),
+  career_type: z.string().nullable().optional(),
   work_mode: z.string().nullable().optional(),
   date_posted: z
     .string()
@@ -73,6 +74,7 @@ export const form_attrs: Array<keyof CareerFormFields> = [
   "salary_range",
   "application_deadline",
   "career_url",
+  "career_type",
   "work_mode",
   "date_posted",
   "responsibilities",

--- a/lms/types/index.ts
+++ b/lms/types/index.ts
@@ -176,6 +176,7 @@ export interface Career {
   salary_range?: string;
   application_deadline?: string;
   career_url?: string;
+  career_type?: string;
   work_mode?: string;
   date_posted?: string;
   responsibilities?: string[];


### PR DESCRIPTION
This pull request introduces a new field, `career_type`, to the career form and related interfaces. The changes ensure that the `career_type` field is included in the form schema, form attributes, and the `Career` interface.

Key changes include:

### Form Schema Updates:
* Added `career_type` as a nullable and optional string field in the form schema in `form-type.ts`. ([lms/app/(dashboard)/(routes)/admin/companies/[companyId]/careers/[careerId]/_components/form-type.tsR34](diffhunk://#diff-a45005e5cfa1739c2c546875fe554ac4cbd1f668e776a695a96ac78cafb808b1R34))

### Form Attributes Updates:
* Included `career_type` in the list of form attributes in `form-type.ts`. ([lms/app/(dashboard)/(routes)/admin/companies/[companyId]/careers/[careerId]/_components/form-type.tsR77](diffhunk://#diff-a45005e5cfa1739c2c546875fe554ac4cbd1f668e776a695a96ac78cafb808b1R77))

### Interface Updates:
* Added `career_type` as an optional string property in the `Career` interface in `index.ts`.